### PR TITLE
Applied AD_VIEWABLE as the impression tracking method.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ Note the first digit of every adapter version corresponds to the major version o
 Adapters are compatible with any Chartboost Mediation SDK version within that major version.
 
 ### 4.2.17.0.2
-- Banner impressions are now tracked on ad show using the AD_VIEWABLE method.
+- Banner impressions are now tracked on ad show using ImpressionTrackingMethod.AD_VIEWABLE.
 
 ### 4.2.17.0.1
 - Updated to handle recent AdFormat changes.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ Note the first digit of every adapter version corresponds to the major version o
 Adapters are compatible with any Chartboost Mediation SDK version within that major version.
 
 ### 4.2.17.0.2
-- Applied AD_VIEWABLE as the impression tracking method for HyBidAdView banners.
+- Banner impressions are now tracked on ad show using the AD_VIEWABLE method.
 
 ### 4.2.17.0.1
 - Updated to handle recent AdFormat changes.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 Note the first digit of every adapter version corresponds to the major version of the Chartboost Mediation SDK compatible with that adapter. 
 Adapters are compatible with any Chartboost Mediation SDK version within that major version.
 
+### 4.2.17.0.2
+- Applied AD_VIEWABLE as the impression tracking method for HyBidAdView banners.
+
 ### 4.2.17.0.1
 - Updated to handle recent AdFormat changes.
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ The Chartboost Mediation Verve adapter mediates HyBid via the Chartboost Mediati
 
 In your `build.gradle`, add the following entry:
 ```
-    implementation "com.chartboost:chartboost-mediation-adapter-verve:4.2.17.0.1"
+    implementation "com.chartboost:chartboost-mediation-adapter-verve:4.2.17.0.2"
 ```
 
 ## Contributions

--- a/VerveAdapter/build.gradle.kts
+++ b/VerveAdapter/build.gradle.kts
@@ -36,7 +36,7 @@ android {
         minSdk = 21
         targetSdk = 33
         // If you touch the following line, don't forget to update scripts/get_rc_version.zsh
-        android.defaultConfig.versionName = System.getenv("VERSION_OVERRIDE") ?: "4.2.17.0.1"
+        android.defaultConfig.versionName = System.getenv("VERSION_OVERRIDE") ?: "4.2.17.0.2"
         buildConfigField("String", "CHARTBOOST_MEDIATION_VERVE_ADAPTER_VERSION", "\"${android.defaultConfig.versionName}\"")
 
         consumerProguardFiles("proguard-rules.pro")

--- a/VerveAdapter/src/main/java/com/chartboost/mediation/verveadapter/VerveAdapter.kt
+++ b/VerveAdapter/src/main/java/com/chartboost/mediation/verveadapter/VerveAdapter.kt
@@ -25,6 +25,7 @@ import net.pubnative.lite.sdk.HyBidError
 import net.pubnative.lite.sdk.HyBidErrorCode
 import net.pubnative.lite.sdk.interstitial.HyBidInterstitialAd
 import net.pubnative.lite.sdk.models.AdSize
+import net.pubnative.lite.sdk.models.ImpressionTrackingMethod
 import net.pubnative.lite.sdk.rewarded.HyBidRewardedAd
 import net.pubnative.lite.sdk.utils.Logger
 import net.pubnative.lite.sdk.views.HyBidAdView
@@ -359,8 +360,10 @@ class VerveAdapter : PartnerAdapter {
         listener: PartnerAdListener
     ): Result<PartnerAd> {
         return suspendCancellableCoroutine { continuation ->
-            val hyBidAdView = HyBidAdView(context)
-            hyBidAdView.setAdSize(getHyBidAdSize(request.size))
+            val hyBidAdView = HyBidAdView(context).apply {
+                setAdSize(getHyBidAdSize(request.size))
+                setTrackingMethod(ImpressionTrackingMethod.AD_VIEWABLE)
+            }
             val hyBidAdViewListener = object : HyBidAdView.Listener {
                 val partnerAd = PartnerAd(
                     ad = hyBidAdView,


### PR DESCRIPTION
- Set the banner impression tracking method to be on ad viewable, to be on parity with our other adapters.
- Updated adapter version to `4.2.17.0.2`