### PR TITLE
Pass "signal" instead of "adm" from partner ad response.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 Note the first digit of every adapter version corresponds to the major version of the Chartboost Mediation SDK compatible with that adapter. 
 Adapters are compatible with any Chartboost Mediation SDK version within that major version.
 
+### 4.3.0.2.1
+- Updated to pass "signal" instead of "adm".
+
 ### 4.3.0.2.0
 - This version of the adapter has been certified with HyBid SDK 3.0.2.
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ The Chartboost Mediation Verve adapter mediates HyBid via the Chartboost Mediati
 
 In your `build.gradle`, add the following entry:
 ```
-    implementation "com.chartboost:chartboost-mediation-adapter-verve:4.3.0.2.0"
+    implementation "com.chartboost:chartboost-mediation-adapter-verve:4.3.0.2.1"
 ```
 
 ## Contributions

--- a/VerveAdapter/build.gradle.kts
+++ b/VerveAdapter/build.gradle.kts
@@ -36,7 +36,7 @@ android {
         minSdk = 21
         targetSdk = 33
         // If you touch the following line, don't forget to update scripts/get_rc_version.zsh
-        android.defaultConfig.versionName = System.getenv("VERSION_OVERRIDE") ?: "4.3.0.2.0"
+        android.defaultConfig.versionName = System.getenv("VERSION_OVERRIDE") ?: "4.3.0.2.1"
         buildConfigField("String", "CHARTBOOST_MEDIATION_VERVE_ADAPTER_VERSION", "\"${android.defaultConfig.versionName}\"")
 
         consumerProguardFiles("proguard-rules.pro")

--- a/VerveAdapter/src/main/java/com/chartboost/mediation/verveadapter/VerveAdapter.kt
+++ b/VerveAdapter/src/main/java/com/chartboost/mediation/verveadapter/VerveAdapter.kt
@@ -171,9 +171,9 @@ class VerveAdapter : PartnerAdapter {
         PartnerLogController.log(BIDDER_INFO_FETCH_STARTED)
 
         return withContext(Dispatchers.IO) {
-            val token = HyBid.getAppToken() ?: ""
+            val signalData = HyBid.getCustomRequestSignalData(context, "cb") ?: ""
             PartnerLogController.log(if (token.isEmpty()) BIDDER_INFO_FETCH_FAILED else BIDDER_INFO_FETCH_SUCCEEDED)
-            mapOf("app_auth_token" to token)
+            mapOf("signal_data" to signalData)
         }
     }
 
@@ -429,10 +429,11 @@ class VerveAdapter : PartnerAdapter {
                     }
                 }
 
-            if (request.adm.isNullOrEmpty()) {
+            val signalData = request.partnerSettings["signal"] as? String ?: ""
+            if (signalData.isEmpty()) {
                 hyBidAdView.load(request.partnerPlacement, hyBidAdViewListener)
             } else {
-                hyBidAdView.renderCustomMarkup(request.adm, hyBidAdViewListener)
+                hyBidAdView.renderAd(signalData, hyBidAdViewListener)
             }
         }
     }
@@ -478,10 +479,11 @@ class VerveAdapter : PartnerAdapter {
                         buildInterstitialAdListener(request, listener, continuation),
                     ).also {
                         loadIdToHyBidInterstitialAds[request.identifier] = it
+                        val signalData = request.partnerSettings["signal"] as? String ?: ""
                         if (request.adm.isNullOrEmpty()) {
                             it.load()
                         } else {
-                            it.prepareCustomMarkup(request.adm)
+                            it.prepareAd(signalData)
                         }
                     }
                 }
@@ -492,10 +494,11 @@ class VerveAdapter : PartnerAdapter {
                         buildRewardedAdListener(request, listener, continuation),
                     ).also {
                         loadIdToHyBidRewardedAds[request.identifier] = it
-                        if (request.adm.isNullOrEmpty()) {
+                        val signalData = request.partnerSettings["signal"] as? String ?: ""
+                        if (signalData.isEmpty()) {
                             it.load()
                         } else {
-                            it.prepareCustomMarkup(request.adm)
+                            it.prepareAd(signalData)
                         }
                     }
                 }

--- a/VerveAdapter/src/main/java/com/chartboost/mediation/verveadapter/VerveAdapter.kt
+++ b/VerveAdapter/src/main/java/com/chartboost/mediation/verveadapter/VerveAdapter.kt
@@ -172,7 +172,7 @@ class VerveAdapter : PartnerAdapter {
 
         return withContext(Dispatchers.IO) {
             val signalData = HyBid.getCustomRequestSignalData(context, "cb") ?: ""
-            PartnerLogController.log(if (token.isEmpty()) BIDDER_INFO_FETCH_FAILED else BIDDER_INFO_FETCH_SUCCEEDED)
+            PartnerLogController.log(if (signalData.isEmpty()) BIDDER_INFO_FETCH_FAILED else BIDDER_INFO_FETCH_SUCCEEDED)
             mapOf("signal_data" to signalData)
         }
     }


### PR DESCRIPTION
- Updated adapter to use the "signal" from the ad response instead of the adm.
- Updated CHANGELOG, README, & build.gradle files to `4.3.0.2.1`